### PR TITLE
Support for having the same route in different versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,12 @@ Version.prototype.use = function(options) {
   this._error = options.error || 406;
 };
 
+var has_routing_path = function (router, path) {
+  return router.stack.some(function(route) {
+    return route.regexp.test(path);
+  });
+};
+
 /**
  * Re-route to middleware based on version
  *
@@ -41,7 +47,10 @@ Version.prototype.reroute = function(reroute_map) {
       for (var i=0; i<versions.length; i++) {
         var version = Number(versions[i]);
         if (match[1] >= version) {
-          return reroute_map[version](req, res, next);
+          var router = reroute_map[version];
+          if (has_routing_path(router, req.path)) {
+            return router(req, res, next);
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "homepage": "https://github.com/peralmq/express-route-versioning",
   "devDependencies": {
     "chai": "^1.9.2",
+    "express": "^4.12.1",
     "mocha": "^2.0.1",
-    "should": "^4.1.0"
+    "should": "^4.1.0",
+    "supertest": "^0.15.0"
   }
 }


### PR DESCRIPTION
i.e.
`GET /example` using `version=1`
and
`GET /example` using `version=2`