### PR TITLE
Handle weird case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,10 @@ var has_matching_route = function (router, req) {
   var path = req.path;
   var method = req.method.toLowerCase();
   return router.stack.some(function(layer) {
+    if (!layer.route) {
+      return false;
+    }
+
     var matches_method = layer.route.methods._all || Boolean(layer.route.methods[method]);
     return layer.match(path) && matches_method;
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-route-versioning",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Express middleware that re-routes requests based on HTTP header value",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
Wasn't able to figure out why this was happening exactly since it only happens once I've deployed something to Heroku (so not reproducible locally). But for some reason the router's layer's `.route` property can be `undefined` sometimes and that broke some re-routing. I.e.: 
```js
{ handle: [Function: sentinel],
  name: 'sentinel',
  params: undefined,
  path: undefined,
  keys: [],
  regexp: { /^\/?(?=\/|$)/i fast_slash: true },
  route: undefined } ]

```