### PR TITLE
Fix has_matching_route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,9 @@ Version.prototype.use = function(options) {
 var has_matching_route = function (router, path, method) {
   return router.stack.some(function(layer) {
     if (layer.name === 'router' && layer.match(path)) {
-      var layerPath = layer.regexp.exec(path)[0];
-      var subPath = path.substr(layerPath.length);
-      return has_matching_route(layer.handle, subPath, method);
+      var layer_path = layer.regexp.exec(path)[0];
+      var sub_path = path.substr(layer_path.length);
+      return has_matching_route(layer.handle, sub_path, method);
     }
 
     if (!layer.route) {
@@ -56,7 +56,7 @@ Version.prototype.reroute = function(reroute_map) {
     var match = grab.exec(header_value);
     var path = req.path;
     var method = req.method.toLowerCase();
-    var routeHandlerExist = false;
+    var route_handler_exist = false;
 
     var versions = Object.keys(reroute_map).reverse();
     for (var i=0; i<versions.length; i++) {
@@ -64,7 +64,7 @@ Version.prototype.reroute = function(reroute_map) {
       var router = reroute_map[version];
 
       if (has_matching_route(router, path, method)) {
-        routeHandlerExist = true;
+        route_handler_exist = true;
 
         if (match && match[1] >= version) {
           return router(req, res, next);
@@ -72,7 +72,7 @@ Version.prototype.reroute = function(reroute_map) {
       }
     }
 
-    if (routeHandlerExist) {
+    if (route_handler_exist) {
       return res.status(error).end();
     }
     return next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,14 @@ Version.prototype.use = function(options) {
   this._error = options.error || 406;
 };
 
-var has_matching_route = function (router, req) {
-  var path = req.path;
-  var method = req.method.toLowerCase();
+var has_matching_route = function (router, path, method) {
   return router.stack.some(function(layer) {
+    if (layer.name === 'router' && layer.match(path)) {
+      var layerPath = layer.regexp.exec(path)[0];
+      var subPath = path.substr(layerPath.length);
+      return has_matching_route(layer.handle, subPath, method);
+    }
+
     if (!layer.route) {
       return false;
     }
@@ -46,16 +50,20 @@ Version.prototype.reroute = function(reroute_map) {
   var header = this._header;
   var grab = this._grab;
   var error = this._error;
+
   return function(req, res, next) {
     var header_value = req.headers[header];
     var match = grab.exec(header_value);
+    var path = req.path;
+    var method = req.method.toLowerCase();
+
     if (match) {
       var versions = Object.keys(reroute_map).reverse();
       for (var i=0; i<versions.length; i++) {
         var version = Number(versions[i]);
         if (match[1] >= version) {
           var router = reroute_map[version];
-          if (has_matching_route(router, req)) {
+          if (has_matching_route(router, path, method)) {
             return router(req, res, next);
           }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,20 +56,26 @@ Version.prototype.reroute = function(reroute_map) {
     var match = grab.exec(header_value);
     var path = req.path;
     var method = req.method.toLowerCase();
+    var routeHandlerExist = false;
 
-    if (match) {
-      var versions = Object.keys(reroute_map).reverse();
-      for (var i=0; i<versions.length; i++) {
-        var version = Number(versions[i]);
-        if (match[1] >= version) {
-          var router = reroute_map[version];
-          if (has_matching_route(router, path, method)) {
-            return router(req, res, next);
-          }
+    var versions = Object.keys(reroute_map).reverse();
+    for (var i=0; i<versions.length; i++) {
+      var version = Number(versions[i]);
+      var router = reroute_map[version];
+
+      if (has_matching_route(router, path, method)) {
+        routeHandlerExist = true;
+
+        if (match && match[1] >= version) {
+          return router(req, res, next);
         }
       }
     }
-    return res.status(error).end();
+
+    if (routeHandlerExist) {
+      return res.status(error).end();
+    }
+    return next();
   };
 };
 

--- a/tests.js
+++ b/tests.js
@@ -14,14 +14,14 @@ describe('express-route-versioning', function() {
     one = express.Router(),
     two = express.Router(),
     three = express.Router(),
-    subRouter = express.Router()
+    sub_router = express.Router()
     ;
 
-    subRouter.get('/sub-route', function(req, res, next) { return res.send('sub-route') ;});
+    sub_router.get('/sub-route', function(req, res, next) { return res.send('sub-route') ;});
     one.all('/example', function(req, res, next) { return res.send('one') ;});
     two.get('/example', function(req, res, next) { return res.send('two') ;});
 
-    two.use('/base-route', subRouter);
+    two.use('/base-route', sub_router);
 
     version.use({
       'header': 'accept',
@@ -85,13 +85,13 @@ describe('express-route-versioning', function() {
 
       it('should work with sub routers', function(done) {
         supertest(app)
-          .get('/base-route/sub-route')
-          .set('accept', '/vnd.mycompany.com+json; version=2')
-          .expect(200)
-          .expect(function(res) {
-            expect(res.text).to.equal('sub-route');
-          })
-          .end(done);
+        .get('/base-route/sub-route')
+        .set('accept', '/vnd.mycompany.com+json; version=2')
+        .expect(200)
+        .expect(function(res) {
+          expect(res.text).to.equal('sub-route');
+        })
+        .end(done);
       });
 
       it('should return 406 (HTTP status code NOT ACCEPTABLE) if no version match', function(done) {
@@ -119,10 +119,10 @@ describe('express-route-versioning', function() {
 
       it('should return 404 (HTTP status code NOT FOUND) if a route is not defined in any version', function(done) {
         supertest(app)
-          .get('/anyRouteThatDoesntExist')
-          .set('accept', 'vnd.mycompany.com+json; version=1')
-          .expect(404)
-          .end(done);
+        .get('/anyRouteThatDoesntExist')
+        .set('accept', 'vnd.mycompany.com+json; version=1')
+        .expect(404)
+        .end(done);
       });
     });
 

--- a/tests.js
+++ b/tests.js
@@ -13,11 +13,15 @@ describe('express-route-versioning', function() {
     var express = require('express'),
     one = express.Router(),
     two = express.Router(),
-    three = express.Router()
+    three = express.Router(),
+    subRouter = express.Router()
     ;
 
+    subRouter.get('/sub-route', function(req, res, next) { return res.send('sub-route') ;});
     one.all('/example', function(req, res, next) { return res.send('one') ;});
     two.get('/example', function(req, res, next) { return res.send('two') ;});
+
+    two.use('/base-route', subRouter);
 
     version.use({
       'header': 'accept',
@@ -77,6 +81,17 @@ describe('express-route-versioning', function() {
           expect(res.text).to.equal('two');
         })
         .end(done);
+      });
+
+      it('should work with sub routers', function(done) {
+        supertest(app)
+          .get('/base-route/sub-route')
+          .set('accept', '/vnd.mycompany.com+json; version=2')
+          .expect(200)
+          .expect(function(res) {
+            expect(res.text).to.equal('sub-route');
+          })
+          .end(done);
       });
 
       it('should return 406 (HTTP status code NOT ACCEPTABLE) if no version match', function(done) {

--- a/tests.js
+++ b/tests.js
@@ -116,6 +116,14 @@ describe('express-route-versioning', function() {
         .expect(406)
         .end(done);
       });
+
+      it('should return 404 (HTTP status code NOT FOUND) if a route is not defined in any version', function(done) {
+        supertest(app)
+          .get('/anyRouteThatDoesntExist')
+          .set('accept', 'vnd.mycompany.com+json; version=1')
+          .expect(404)
+          .end(done);
+      });
     });
 
     describe('weird cases', function() {


### PR DESCRIPTION
This fixes the two issues described in #5.

1. `has_matching_route` now checks if the route exist in a sub-router
2. The version error status code is only returned if the route exist in ANY version but does not match the version in the request header. If a route doesn’t exist at all you will get a 404 error.

Fixes #5 